### PR TITLE
add tag based publishing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ deploy:
   api_key:
     secure: HNzRiN6I8lLNIJy1WDtRqebusIi0zUONyoUQIIyPQJ0xQB4NkJ5HFdU0o1YIOsfPg+FaARTcz+H27HKtAtRtlbD1B1syj4LdGoQ0GcR0Ew0GBLKd/LtxcnDXR4/3/iVZ9C3rJ4YosOSL9pCm96P19AqVaEIUHPqRUOJznlvoznRFbzpJGuV9uROsRGee7heVuttOasEDFF3I3Z2ZqiY6f2Fg/1PXu0eNUlY+FEE2KTNOpwSCXAIAkjBB5sfmU4hvl2W6ZSaPweDJ+AxIiqDqb0hL08/5ucUNfoRl8QAp+Wyg3MHV5QJDDHLln6bJ76HzjT6/dWdOzZnaKqGkKAmfumgG0+UvNiZztN0sa9QMYpNi72LsZ8LTCbVy1jTBq+yCltNmJH/Hcsxhgnp2rWWN1Vji+38kmwLhmycppHelccKNkvSTrxuQaHLO5MIpwJW3zl5mIl+qZw6kol//pDPjDclDZQuXrcNdfRkWpoNpcVgd7fxApA+7omjWdwImdJDzG4iSQbZzy24nYIwMuJJdUEP1s3Go6IZeQPrNgHALiL13TJfKlLW70oQC0CAvz2DLjG5wThoutEQCvTMYxkq11eLeQ0entKhQ54APLisHz9Ks7VdeNN1tTHesVqwanM8lXhKJe0s3br04bQDl/37K5DkCb8agf81pgn80o+xVzp4=
   file_glob: true
-  file: "*.zip"
+  file: releases/*
+  skip_cleanup: true
   on:
-    repo: jgensler8/terraform-provider-minikube
-    branch: master
+    tags: true

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 RELEASE_VERSION=v0.4.0
+RELEASE_DIR=releases
 GOARCH?=amd64
 BINARY=terraform-provider-minikube_${RELEASE_VERSION}_x4
 LINUX_RELEASE=terraform-provider-minikube_${RELEASE_VERSION}_linux_${GOARCH}
 MAC_RELEASE=terraform-provider-minikube_${RELEASE_VERSION}_darwin_${GOARCH}
 
-default: deps assets_hack linux mac
+default: deps assets_hack linux mac stage
 
 deps:
 	go get -d -v ./...
@@ -13,6 +14,7 @@ assets_hack:
 	make -C ${GOPATH}/src/k8s.io/minikube pkg/minikube/assets/assets.go
 
 clean:
+	rm -rf "${RELEASE_DIR}"
 	rm ${LINUX_RELEASE} ${MAC_RELEASE} ${LINUX_RELEASE}.zip ${MAC_RELEASE}.zip
 
 linux:
@@ -24,3 +26,8 @@ mac:
 	GOOS=darwin GOARCH=${GOARCH} go build -o "${BINARY}"
 	zip "${MAC_RELEASE}.zip" "${BINARY}"
 	rm "${BINARY}"
+
+stage:
+	mkdir "${RELEASE_DIR}"
+	mv "${LINUX_RELEASE}.zip" "${RELEASE_DIR}"
+	mv "${MAC_RELEASE}.zip" "${RELEASE_DIR}"


### PR DESCRIPTION
change file glob to be at end. Actually uploads releases to Github. Should fix #4.

Note that binaries are not statically linked:

```
$ file ./terraform-provider-minikube_v0.4.0_x4
terraform-provider-minikube_v0.4.0_x4: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked (uses shared libs), not stripped

$ file ./terraform-provider-minikube_v0.4.0_x4
./terraform-provider-minikube_v0.4.0_x4 2: Mach-O 64-bit executable x86_64
```