### PR TITLE
upgrade travis-ci build to 1.12. move asset hack…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
+env:
+- GO111MODULE=on
 go:
-- 1.11.x
+- 1.12.x
 deploy:
   provider: releases
   api_key:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
-RELEASE_VERSION=v0.4.0
+RELEASE_VERSION=v0.5.0
 RELEASE_DIR=releases
 GOARCH?=amd64
 BINARY=terraform-provider-minikube_${RELEASE_VERSION}_x4
 LINUX_RELEASE=terraform-provider-minikube_${RELEASE_VERSION}_linux_${GOARCH}
 MAC_RELEASE=terraform-provider-minikube_${RELEASE_VERSION}_darwin_${GOARCH}
+MINIKUBE_VERSION=v0.30.0
 
 default: deps assets_hack linux mac stage
 
 deps:
-	go get -d -v ./...
+	go get -d
 
 assets_hack:
-	make -C ${GOPATH}/src/k8s.io/minikube pkg/minikube/assets/assets.go
+	chmod -R 777 ${GOPATH}/pkg/mod/k8s.io/minikube@${MINIKUBE_VERSION}
+	go get -u github.com/jteeuwen/go-bindata/...
+	go-bindata -nomemcopy -o ${GOPATH}/pkg/mod/k8s.io/minikube@${MINIKUBE_VERSION}/pkg/minikube/assets/assets.go -pkg assets ${GOPATH}/pkg/mod/k8s.io/minikube@${MINIKUBE_VERSION}/deploy/addons/...
 
 clean:
 	rm -rf "${RELEASE_DIR}"

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/johanneswuerbach/nfsexports v0.0.0-20151229182559-a9068f3f0daa
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 // indirect
 	github.com/json-iterator/go v1.1.5
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 // indirect
 	github.com/keybase/go-crypto v0.0.0-20180920171116-0b2a91ace448 // indirect
 	github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169

--- a/go.sum
+++ b/go.sum
@@ -36,7 +36,7 @@ github.com/cpuguy83/go-md2man v1.0.4/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dY
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/docker/docker v0.0.0-20180917213351-bbe08dc7f0b9 h1:O3zcICQNyL1YDcdlUGqNkhXoupFcDPfj7n8cTtLSIWY=
+github.com/docker/docker v0.0.0-20180917213351-bbe08dc7f0b9 h1:dArdEP6A7F7aoAph4Gs505ME7QSBjjbRdpklFV384KU=
 github.com/docker/docker v0.0.0-20180917213351-bbe08dc7f0b9/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.0.0-20170127094116-9e638d38cf69 h1:N4WAsrRIb+4U1yIwJO3FMrLnrr61ael894nygpViQTU=
 github.com/docker/go-units v0.0.0-20170127094116-9e638d38cf69/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -64,7 +64,7 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-containerregistry v0.0.0-20180815195620-3165313d6d3f h1:r0kIiA6uoeBOCVhOI09PTJ1qNGRBxXnVAZqPkTk9QVI=
+github.com/google/go-containerregistry v0.0.0-20180815195620-3165313d6d3f h1:HvPjBBFa7VkWUJkBrIKIQMeAdeiJpZxp6833H6T1oBg=
 github.com/google/go-containerregistry v0.0.0-20180815195620-3165313d6d3f/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 h1:ScAXWS+TR6MZKex+7Z8rneuSJH+FSDqd6ocQyl+ZHo4=
@@ -84,7 +84,7 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de/go.mod h1:xIwEieBHERyEvaeKF/TcHh1Hu+lxPM+n2vT1+g9I4m4=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-getter v0.0.0-20180809191950-4bda8fa99001 h1:MFPzqpPED05pFyGjNPJEC2sXM6EHTzFyvX+0s0JoZ48=
+github.com/hashicorp/go-getter v0.0.0-20180809191950-4bda8fa99001 h1:qC+3MHkvfCXb1cA9YDpWZ7np8tPOXZceLrW+xyqOgmk=
 github.com/hashicorp/go-getter v0.0.0-20180809191950-4bda8fa99001/go.mod h1:6rdJFnhkXnzGOJbvkrdv4t9nLwKcVA+tmbQeUlkIzrU=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f h1:Yv9YzBlAETjy6AOX9eLBZ3nshNVRREgerT/3nvxlGho=
@@ -134,6 +134,8 @@ github.com/johanneswuerbach/nfsexports v0.0.0-20151229182559-a9068f3f0daa/go.mod
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/keybase/go-crypto v0.0.0-20180920171116-0b2a91ace448/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169 h1:YUrU1/jxRqnt0PSrKj1Uj/wEjk/fjnE80QFfi2Zlj7Q=
@@ -298,11 +300,11 @@ k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apiserver v0.0.0-20180914001516-67c892841170 h1:a9iLDj8v4x5/JpYsgKWSv3k6c5Q7M8dsyrAt4GLOzKQ=
 k8s.io/apiserver v0.0.0-20180914001516-67c892841170/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
-k8s.io/client-go v0.0.0-20180806134042-1f13a808da65 h1:3w7osyUaXe5a1wxJrqkfjRhqYMfi9pCiB64J9bmtszk=
+k8s.io/client-go v0.0.0-20180806134042-1f13a808da65 h1:kQX7jEIMYrWV9XqFN4usRaBLzCu7fd/qsCXxbgf3+9g=
 k8s.io/client-go v0.0.0-20180806134042-1f13a808da65/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kube-openapi v0.0.0-20180216212618-50ae88d24ede h1:YOWlONzJUq456SnNYPcK/org5asA+LU6AzNBm+l/04o=
 k8s.io/kube-openapi v0.0.0-20180216212618-50ae88d24ede/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
-k8s.io/kubernetes v1.11.3 h1:eO7Ia/0gVOFphtPiIt3LUKWRsQJpOk8LucurvvbMzGA=
+k8s.io/kubernetes v1.11.3 h1:49Pz+NOerox7nZ9F0m/fWv2MIuFDU5cDAoYMozurx1k=
 k8s.io/kubernetes v1.11.3/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-k8s.io/minikube v0.30.0 h1:21fNnItY6aCDADy46c/O31aUd42WpW9nI6y36d4Jpso=
+k8s.io/minikube v0.30.0 h1:1Nbd5wVAIFL7aQySq6nNxUgk4Wc9u0v79oRPu3p/9oY=
 k8s.io/minikube v0.30.0/go.mod h1:H+QXQu+JESf82j7aynF6ELHqC+oGv5ZDN7ZPw4qQDlo=


### PR DESCRIPTION
move "asset hack" from remote Makefile into this repo (go modules mess up the pathing that is assumed in their remote scripts)

There was some trouble upgrading to minikube v1.0.0 because of client-go dependency version issues. Only a few minor api changes otherwise.

helps #10 